### PR TITLE
Add user login for logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GIT_REF := $(shell git rev-parse --short=7 HEAD)
 VERSION ?= commit-$(GIT_REF)
 
 # Setup GCP Registry Variables
-GCR_PROJECT := kouzoh-p-keisuke-yamashita
+GCR_PROJECT :=
 REGISTRY := gcr.io/$(GCR_PROJECT)
 IMAGE := $(REGISTRY)/$(SERVICE_NAME):$(VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GIT_REF := $(shell git rev-parse --short=7 HEAD)
 VERSION ?= commit-$(GIT_REF)
 
 # Setup GCP Registry Variables
-GCR_PROJECT :=
+GCR_PROJECT := kouzoh-p-keisuke-yamashita
 REGISTRY := gcr.io/$(GCR_PROJECT)
 IMAGE := $(REGISTRY)/$(SERVICE_NAME):$(VERSION)
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -22,7 +22,7 @@ type ErrorResponse struct {
 }
 
 type Client interface {
-	GetUserInfo(string) (*http.Response, error)
+	GetUserInfo(string) (*UserInfo, error)
 	GetOrgs(string) (Organizations, error)
 }
 
@@ -73,7 +73,7 @@ type UserInfo struct {
 	Login string `json:"login,omitempty"`
 }
 
-func (c client) GetUserInfo(token string) (*http.Response, error) {
+func (c client) GetUserInfo(token string) (*UserInfo, error) {
 	req, err := http.NewRequest("GET", c.baseURL+"/"+userInfoPath, nil)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,12 @@ func (c client) GetUserInfo(token string) (*http.Response, error) {
 		return nil, fmt.Errorf("request failed with status code %d with message %s", resp.StatusCode, err.Message)
 	}
 
-	return resp, nil
+	var u UserInfo
+	if err := json.NewDecoder(resp.Body).Decode(&u); err != nil {
+		return nil, err
+	}
+
+	return &u, nil
 }
 
 func (c client) GetOrgs(token string) (Organizations, error) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -69,6 +69,10 @@ func (orgs Organizations) MarshalLogArray(encoder zapcore.ArrayEncoder) error {
 	return nil
 }
 
+type UserInfo struct {
+	Login string `json:"login,omitempty"`
+}
+
 func (c client) GetUserInfo(token string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", c.baseURL+"/"+userInfoPath, nil)
 	if err != nil {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -84,6 +84,7 @@ func (c client) GetUserInfo(token string) (*UserInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		err := decodeError(resp.Body)

--- a/internal/github/github.mock.go
+++ b/internal/github/github.mock.go
@@ -5,10 +5,8 @@
 package github
 
 import (
-	http "net/http"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface
@@ -35,10 +33,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // GetUserInfo mocks base method
-func (m *MockClient) GetUserInfo(arg0 string) (*http.Response, error) {
+func (m *MockClient) GetUserInfo(arg0 string) (*UserInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserInfo", arg0)
-	ret0, _ := ret[0].(*http.Response)
+	ret0, _ := ret[0].(*UserInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -70,26 +70,23 @@ func (p *proxy) OAuthProxyHandler() http.Handler {
 func (p *proxy) oauthProxyHandler(w http.ResponseWriter, r *http.Request) {
 	header := r.Header.Get("Authorization")
 	if header == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(errResps[http.StatusBadRequest]))
 		p.logger.Error("no authorization header")
+		http.Error(w, "no authorization header", http.StatusBadRequest)
 		return
 	}
 
 	str := strings.Split(header, " ")
 	if len(str) != 2 {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(errResps[http.StatusBadRequest]))
 		p.logger.Error("bad request")
+		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
 
 	tokenType, token := str[0], str[1]
 	if strings.ToLower(tokenType) != "bearer" {
-		w.WriteHeader(http.StatusBadRequest)
 		msg := "token type should be bearer type"
-		w.Write([]byte(msg))
 		p.logger.Error("msg", zap.String("tokenType", tokenType))
+		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}
 
@@ -97,8 +94,7 @@ func (p *proxy) oauthProxyHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := "error while getting user info"
 		p.logger.Error(msg, zap.Error(err))
-		w.WriteHeader(http.StatusBadGateway)
-		w.Write([]byte(msg))
+		http.Error(w, msg, http.StatusBadGateway)
 		return
 	}
 
@@ -106,8 +102,7 @@ func (p *proxy) oauthProxyHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := "error while getting user's organization info"
 		p.logger.Error(msg, zap.Error(err))
-		w.WriteHeader(http.StatusBadGateway)
-		w.Write([]byte(msg))
+		http.Error(w, msg, http.StatusBadGateway)
 		return
 	}
 
@@ -118,9 +113,7 @@ func (p *proxy) oauthProxyHandler(w http.ResponseWriter, r *http.Request) {
 			b, err := json.Marshal(u)
 			if err != nil {
 				msg := "failed to marshal body"
-				p.logger.Error(msg, zap.Error(err))
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(msg))
+				http.Error(w, msg, http.StatusInternalServerError)
 				return
 			}
 			w.Write(b)
@@ -129,8 +122,7 @@ func (p *proxy) oauthProxyHandler(w http.ResponseWriter, r *http.Request) {
 
 		msg := "user is not a member of allowed orgs"
 		p.logger.Info(msg, zap.String("allowedOrganization", p.allowedOrg), zap.Array("organizations", orgs), zap.String("user", u.Login))
-		w.WriteHeader(http.StatusForbidden)
-		w.Write([]byte(msg))
+		http.Error(w, msg, http.StatusForbidden)
 		return
 	}
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -17,7 +17,8 @@ const (
 	testBearer     = "Bearer "
 )
 
-func getUserInfo(login string) *github.UserInfo {
+func getTestUserInfo(t *testing.T, login string) *github.UserInfo {
+	t.Helper()
 	return &github.UserInfo{
 		Login: login,
 	}
@@ -44,7 +45,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{testAllowedOrg}, {"keke-test"}},
 			false,
-			getUserInfo("KeisukeYamashita"),
+			getTestUserInfo(t, "KeisukeYamashita"),
 			false,
 		},
 		"ok bypass": {
@@ -54,7 +55,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			"",
 			[]github.Organization{{testAllowedOrg}, {"keke-test"}},
 			false,
-			getUserInfo("KeisukeYamashita"),
+			getTestUserInfo(t, "KeisukeYamashita"),
 			false,
 		},
 		"not belonging to org": {
@@ -64,7 +65,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			getUserInfo("KeisukeYamashita"),
+			getTestUserInfo(t, "KeisukeYamashita"),
 			false,
 		},
 		"empty authorization token": {
@@ -74,7 +75,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			getUserInfo("KeisukeYamashita"),
+			getTestUserInfo(t, "KeisukeYamashita"),
 			false,
 		},
 		"missing authorization token": {
@@ -84,7 +85,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			getUserInfo("KeisukeYamashita"),
+			getTestUserInfo(t, "KeisukeYamashita"),
 			false,
 		},
 		"wrong format authorization token": {
@@ -94,7 +95,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			getUserInfo("KeisukeYamashita"),
+			getTestUserInfo(t, "KeisukeYamashita"),
 			false,
 		},
 		"wrong token type": {
@@ -104,7 +105,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			getUserInfo("KeisukeYamashita"),
+			getTestUserInfo("KeisukeYamashita"),
 			false,
 		},
 		"failed to get user info": {
@@ -114,7 +115,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			getUserInfo("KeisukeYamashita"),
+			getTestUserInfo("KeisukeYamashita"),
 			true,
 		},
 		"failed to get orgs": {
@@ -124,7 +125,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			true,
-			getUserInfo("KeisukeYamashita"),
+			getTestUserInfo("KeisukeYamashita"),
 			false,
 		},
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -17,6 +17,12 @@ const (
 	testBearer     = "Bearer "
 )
 
+func getUserInfo(login string) *github.UserInfo {
+	return &github.UserInfo{
+		Login: login,
+	}
+}
+
 func TestProxy_OAuthProxyHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -28,7 +34,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 		allowedOrg             string
 		getOrgs                github.Organizations
 		failGetOrgs            bool
-		getUserInfo            *http.Response
+		getUserInfo            *github.UserInfo
 		failGetUserInfo        bool
 	}{
 		"ok": {
@@ -38,7 +44,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{testAllowedOrg}, {"keke-test"}},
 			false,
-			&http.Response{Body: &http.NoBody},
+			getUserInfo("KeisukeYamashita"),
 			false,
 		},
 		"ok bypass": {
@@ -48,7 +54,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			"",
 			[]github.Organization{{testAllowedOrg}, {"keke-test"}},
 			false,
-			&http.Response{Body: &http.NoBody},
+			getUserInfo("KeisukeYamashita"),
 			false,
 		},
 		"not belonging to org": {
@@ -58,7 +64,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			&http.Response{Body: &http.NoBody},
+			getUserInfo("KeisukeYamashita"),
 			false,
 		},
 		"empty authorization token": {
@@ -68,7 +74,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			&http.Response{Body: &http.NoBody},
+			getUserInfo("KeisukeYamashita"),
 			false,
 		},
 		"missing authorization token": {
@@ -78,7 +84,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			&http.Response{Body: &http.NoBody},
+			getUserInfo("KeisukeYamashita"),
 			false,
 		},
 		"wrong format authorization token": {
@@ -88,7 +94,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			&http.Response{Body: &http.NoBody},
+			getUserInfo("KeisukeYamashita"),
 			false,
 		},
 		"wrong token type": {
@@ -98,7 +104,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			&http.Response{Body: &http.NoBody},
+			getUserInfo("KeisukeYamashita"),
 			false,
 		},
 		"failed to get user info": {
@@ -108,7 +114,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			&http.Response{Body: &http.NoBody},
+			getUserInfo("KeisukeYamashita"),
 			true,
 		},
 		"failed to get orgs": {
@@ -118,7 +124,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			true,
-			&http.Response{Body: &http.NoBody},
+			getUserInfo("KeisukeYamashita"),
 			false,
 		},
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -105,7 +105,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			getTestUserInfo("KeisukeYamashita"),
+			getTestUserInfo(t, "KeisukeYamashita"),
 			false,
 		},
 		"failed to get user info": {
@@ -115,7 +115,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			false,
-			getTestUserInfo("KeisukeYamashita"),
+			getTestUserInfo(t, "KeisukeYamashita"),
 			true,
 		},
 		"failed to get orgs": {
@@ -125,7 +125,7 @@ func TestProxy_OAuthProxyHandler(t *testing.T) {
 			testAllowedOrg,
 			[]github.Organization{{"keke-test"}},
 			true,
-			getTestUserInfo("KeisukeYamashita"),
+			getTestUserInfo(t, "KeisukeYamashita"),
 			false,
 		},
 	}


### PR DESCRIPTION
## What

As title. 

## Test

### Unit test

The Logs seem okay

```
2020-08-27T10:58:13.264+0900    INFO    proxy/proxy.go:138      user is allowed to bypass with any GitHub Organization  {"organizations": ["testOrg", "keke-test"], "user": "KeisukeYamashita"}
2020-08-27T10:58:13.264+0900    INFO    proxy/proxy.go:116      organization belonging user     {"allowedOrganization": "testOrg", "organizations": ["testOrg", "keke-test"], "user": "KeisukeYamashita"}
2020-08-27T10:58:13.264+0900    INFO    proxy/proxy.go:131      user is not a member of allowed orgs    {"allowedOrganization": "testOrg", "organizations": ["keke-test"], "user": "KeisukeYamashita"}
```

### Integration test

Deploy the new version.

![image](https://user-images.githubusercontent.com/23056537/91376293-baae3800-e857-11ea-88c8-63ea81c66fa9.png)

Login attempt.

![image](https://user-images.githubusercontent.com/23056537/91376309-c1d54600-e857-11ea-8671-999a957f4fd8.png)

And the logs looks fine 🚀 

![image](https://user-images.githubusercontent.com/23056537/91376357-d6b1d980-e857-11ea-9cbc-028002e4d5cf.png)

## Why

Solves #6  to improve logging.